### PR TITLE
Chefize the cron entries

### DIFF
--- a/recipes/_cronjobs.rb
+++ b/recipes/_cronjobs.rb
@@ -1,0 +1,37 @@
+# Remove this file, since these cron entries should really be expressed as Chef,
+# and I think the backend user's crontab is a good place to put them.
+file '/etc/cron.d/backend' do
+  action :delete
+end
+
+cron 'run-calaccess-raw-import' do
+  user 'backend'
+  minute '08'
+  hour '0'
+  path '/data/backend/env/bin:$PATH'
+
+  command %w{
+    /data/backend/current/cron/cronrunner.py
+      -l /data/etl-reports
+      -o /data/etl-reports/archive
+      -n calaccess
+        python /data/backend/current/disclosure-backend/manage.py downloadcalaccessrawdata --no-color
+        --noinput --verbosity=3
+  }.join(' ')
+end
+
+cron 'run-netfile-import' do
+  user 'backend'
+  minute '08'
+  hour '1'
+  path '/data/backend/env/bin:$PATH'
+
+  command %w{
+    /data/backend/current/cron/cronrunner.py
+      -l /data/etl-reports
+      -o /data/etl-reports/archive
+      -n netfile
+        python /data/backend/current/disclosure-backend/manage.py downloadnetfilerawdata --no-color
+        --noinput --verbosity=3
+  }.join(' ')
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,4 +6,5 @@ package 'python-dev'
 group 'opencal'
 
 include_recipe 'disclosure-cookbook::_nginx'
+include_recipe 'disclosure-cookbook::_cronjobs'
 include_recipe 'disclosure-cookbook::_backend_deploy'


### PR DESCRIPTION
These really should be in version control - so this adds them as entries
in the 'backend' user's crontab instead of the /etc/cron.d/backend file.

FYI @seanius @adborden that now the cronjobs are canonically specified here.
