### PR TITLE
Clean up all but last 5 deploys

### DIFF
--- a/files/default/deploy-backend
+++ b/files/default/deploy-backend
@@ -19,6 +19,7 @@ sudo -i -u backend /bin/bash -exc "
   python $deploy_dir/disclosure-backend/manage.py collectstatic -v1 --noinput;
   ln -sfT $deploy_dir /data/backend/current;
   sudo /sbin/initctl restart disclosure-backend;
+  find /data/backend -maxdepth 1 -name '1*' | sort -g | head -n -5 | xargs rm -rf;
 "
 
 echo "Done!"


### PR DESCRIPTION
We were down to like 6 GB free on /data/backend because old deploys were
clogging up everything. I think we should separate out where the data
actually downloads to... but for now this will make sure things don't
grow too crazily.
