### PR TITLE
Share data between multiple deploys

### DIFF
--- a/files/default/deploy-backend
+++ b/files/default/deploy-backend
@@ -15,6 +15,7 @@ sudo -i -u backend /bin/bash -exc "
   pip install --exists-action w -r $deploy_dir/requirements.txt;
   pip install uwsgi;
   ln -sf /data/backend/settings_local.py $deploy_dir/disclosure/settings_local.py;
+  ln -sfT /data/backend/shared/data $deploy_dir/data;
   python $deploy_dir/manage.py migrate --noinput;
   python $deploy_dir/manage.py collectstatic -v1 --noinput;
   ln -sfT $deploy_dir /data/backend/current;

--- a/recipes/_backend_deploy.rb
+++ b/recipes/_backend_deploy.rb
@@ -2,10 +2,15 @@ user 'backend' do
   home '/data/backend'
 end
 
-directory '/data/backend' do
-  recursive true
-  owner 'backend'
-  group 'backend'
+%w[
+  /data/backend
+  /data/backend/shared/data
+].each do |dirname|
+  directory dirname do
+    recursive true
+    owner 'backend'
+    group 'backend'
+  end
 end
 
 cookbook_file '/usr/local/bin/deploy-backend' do


### PR DESCRIPTION
A prerequisite for continuous deployment, this symlinks the `data`
directory of each deploy into a directory that is shared across all
deploys. This means that downloadnetfilerawdata can benefit from a
speedup if there is already a cached copy of the data from a previous
deploy.
