### PR TITLE
Migrate the `calaccess_raw` database on deploy, too

### DIFF
--- a/files/default/deploy-backend
+++ b/files/default/deploy-backend
@@ -17,6 +17,7 @@ sudo -i -u backend /bin/bash -exc "
   ln -sf /data/backend/settings_local.py $deploy_dir/disclosure/settings_local.py;
   ln -sfT /data/backend/shared/data $deploy_dir/data;
   python $deploy_dir/manage.py migrate --noinput;
+  python $deploy_dir/manage.py migrate --database calaccess_raw --noinput;
   python $deploy_dir/manage.py collectstatic -v1 --noinput;
   ln -sfT $deploy_dir /data/backend/current;
   sudo /sbin/initctl restart disclosure-backend;


### PR DESCRIPTION
While developing just now, I learned the hard way that `manage.py
migrate` only applies the migrations for the "default" database unless
the `--database` flag is used.

Do not be fooled by the command-line output! Even though your migration
is listed in the output of the default database migration command, **if
the DATABASE_ROUTER's `allow_migrate` method returns false, the
migration [silently is turned into a no-op.](https://docs.djangoproject.com/en/1.10/topics/db/multi-db/#allow_migrate)**

We have configured such a DATABASE_ROUTER to separate the raw data into
`calaccess_raw` and the processed data into `opendisclosure`.

As such, it is necessary to always run `manage.py migrate` once for each
database. The README's documented setup instructions are correct -- we
have defined a wrapper command `setuptestserver` which runs migrate
twice.
