### PR TITLE
Allow "backend" user to run deploy-backend

### DIFF
--- a/files/default/deploy-backend
+++ b/files/default/deploy-backend
@@ -7,7 +7,14 @@ deploy_dir=/data/backend/$now
 echo 'Fetching latest commits from https://github.com/caciviclab/disclosure-backend.git...'
 
 echo "Deploying into ${deploy_dir}..."
-sudo -i -u backend /bin/bash -exc "
+
+if [ "$USER" == "backend" ]; then
+  deploy_exec="/bin/bash -exc"
+else
+  deploy_exec="sudo -i -u backend /bin/bash -exc"
+fi
+
+$deploy_exec "
   cd /data/git/disclosure-backend && git fetch;
   mkdir -p $deploy_dir;
   git archive origin/master | tar xC $deploy_dir;


### PR DESCRIPTION
Since the deploy process already runs most of the logic as the backend
user, this adds a quick conditional to not attempt to use "sudo" if the
script is invoked as the backend user.
